### PR TITLE
Fix dyadic Get in hashmap

### DIFF
--- a/hashmap.bqn
+++ b/hashmap.bqn
@@ -38,7 +38,7 @@ HashMap ⇐ {𝕩.Self𝕩}∘{ keys 𝕊 vals: Self⇐{self↩𝕩}
   }
   Get ⇐ {
       𝕊 key: vals ⊑˜ Find key ;
-    d 𝕊 key: Next•_while_(¯1⊸≠◶⟨0,⊢{d↩𝕨⋄𝕩}⍟(¬⊢)key≢⊑⟜keys⟩⊑⟜table) Ind key ⋄ d
+    d 𝕊 key: Next•_while_(¯1⊸≠◶⟨0,⊢{d↩𝕨⊑vals⋄𝕩}⍟(¬⊢)key≢⊑⟜keys⟩⊑⟜table) Ind key ⋄ d
   }
   tombstone ← {⇐}
   Delete ⇐ { 𝕊 key:

--- a/test/hashmap.bqn
+++ b/test/hashmap.bqn
@@ -2,12 +2,13 @@
 
 {
   n ← ≠ k ← 3‿¯π‿"str"‿'k'‿'j'
-  m ← k HashMap v←↕5
+  offset ← 100
+  m ← k HashMap v←offset+↕5
   ! n ≡ m.Count@
   ! (m.Has¨ ≡ ∊⟜k) (¯π+¯1‿0‿1×1e¯15)∾"strike"∾3‿4
-  ! (m.Get¨ ≡ k⊸⊐) 3‿1‿0‿2⊏k
+  ! ((offset-˜m.Get)¨ ≡ k⊸⊐) 3‿1‿0‿2⊏k
   ! ∧´ 0∘m.Get⎊1¨ "k"‿'i'‿¯3
-  ! 4‿'q'‿1 ≡ "pqr" m.Get¨ 'j'‿"k"‿¯π
+  ! ⟨offset+4,'q',offset+1⟩ ≡ "pqr" m.Get¨ 'j'‿"k"‿¯π
   ! m ≡ 3 m.Set "new"
   ! n ≡ m.Count@
   ! "new" ≡ m.Get 3
@@ -22,7 +23,7 @@
   ! 0∘m.Delete⎊1 "str"
   ! (n-1) ≡ m.Count@
   ! 0∘m.Get⎊1 "str"
-  ! (("new"⌾⊑k⊐⊢) ≡ m.Get¨) 3‿¯π‿'k'‿'j'
+  ! (("new"⌾⊑offset+k⊐⊢) ≡ m.Get¨) 3‿¯π‿'k'‿'j'
 
   # Resizing probably
   (k10 ← ≍⍟(↕10) @) m.Set¨ (<"ab")+↕10


### PR DESCRIPTION
Hi,
I found that the dyadic `Get` returns an index for `keys` instead of corresponding data in `vals`.
So it fails the modified test/hashmap.bqn in which ordinals(?) of keys don't match their values.
This PR fixes it and gets all tests passed. (Feel free to rewrite or close :)